### PR TITLE
fix floating footer on sparse pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,15 +45,14 @@
     <script type="module" src="<%= Settings.tableau.base_url %>/javascripts/api/tableau.embedding.3.latest.min.js"></script>
   </head>
 
-  <body>
-<body>
+  <body class="d-flex flex-column" style="min-height: 100vh">
     <%= render NavComponent.new %>
 
     <%= render HeaderComponent.new %>
 
     <%= render FlashComponent.new(flash:) %>
 
-    <div class="container">
+    <div class="container mb-auto flex-1">
 
       <%= yield %>
 


### PR DESCRIPTION
Before:
<img width="1672" height="949" alt="Screenshot 2025-11-05 at 5 52 50 PM" src="https://github.com/user-attachments/assets/cd79c9e0-d507-4bc9-a2eb-d95c793860b4" />

---
After:
<img width="963" height="946" alt="Screenshot 2025-11-05 at 5 55 49 PM" src="https://github.com/user-attachments/assets/becbacca-5c00-4c37-acd2-556afe4e4639" />
