### PR TITLE
fix gb calculation

### DIFF
--- a/app/components/download_dataset_component.rb
+++ b/app/components/download_dataset_component.rb
@@ -25,7 +25,7 @@ class DownloadDatasetComponent < ViewComponent::Base
   end
 
   def file_size
-    tag.div { "Size: #{file.size} GB (uncompressed)" }
+    tag.div { "Size: #{file.size} (uncompressed)" }
   end
 
   def last_updated

--- a/app/models/download_file.rb
+++ b/app/models/download_file.rb
@@ -23,7 +23,14 @@ class DownloadFile
   def size
     zip = Zip::File.open(filepath)
     entry = zip.find_entry(filename.gsub('.zip', '.csv'))
-    (entry.size.to_f / (1024**3)).round(2)
+    size = entry.size
+    # for some reason zip gives decimal file size, i.e. 1.53 gb file returns 1533884797
+    # We need to convert the decimal size (1 kb = 1000 bytes)
+    # to binary size size (1 kb = 1024) for number_to_human_size to work
+    # exponent gives the ratio of exponents for our size and 1 kilobyte which tells us our exponent for converted_bytes
+    exponent = (Math.log(size) / Math.log(1000)).floor
+    converted_bytes = size * (1.024**exponent)
+    ActiveSupport::NumberHelper.number_to_human_size(converted_bytes)
   end
 
   def last_updated

--- a/spec/requests/downloads_spec.rb
+++ b/spec/requests/downloads_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe 'Publications' do
         get '/download'
         expect(response).to have_http_status(:success)
         expect(response.body).to include 'publications_by_department.zip'
+        expect(response.body).to include 'Size: 420 KB (uncompressed)'
         expect(response.body).to include('aria-label="Download publications.zip"')
       end
 


### PR DESCRIPTION
First result shows how to do this correctly: https://stackoverflow.com/questions/30772368/bytes-to-megabytes-in-ruby
Every other suggestion is why it ended up getting done wrong.

Switched to number_to_human_size based on Laura's suggestion.