### PR TITLE
Use human readable size

### DIFF
--- a/app/components/download_dataset_component.rb
+++ b/app/components/download_dataset_component.rb
@@ -25,7 +25,7 @@ class DownloadDatasetComponent < ViewComponent::Base
   end
 
   def file_size
-    tag.div { "Size: #{file.size} GB (uncompressed)" }
+    tag.div { "Size: #{number_to_human_size(file.size)} (uncompressed)" }
   end
 
   def last_updated

--- a/app/models/download_file.rb
+++ b/app/models/download_file.rb
@@ -23,7 +23,7 @@ class DownloadFile
   def size
     zip = Zip::File.open(filepath)
     entry = zip.find_entry(filename.gsub('.zip', '.csv'))
-    (entry.size.to_f / (1024**3)).round(2)
+    entry.size
   end
 
   def last_updated


### PR DESCRIPTION
This is a small change to not display small decimal versions of file sizes.

<img width="1714" height="1124" alt="Screenshot 2025-11-21 at 5 02 58 PM" src="https://github.com/user-attachments/assets/e7324987-a415-40d8-b96a-c71b079c53c5" />

instead of:

<img width="1670" height="1080" alt="Screenshot 2025-11-21 at 5 06 35 PM" src="https://github.com/user-attachments/assets/b4d2a48c-449b-4e09-bd8c-251e75c38ccf" />
