### PR TITLE
Add Bootstrap cards to About page (via AI)

### DIFF
--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -4,36 +4,50 @@
   <h2>Dashboards</h2>
   <p>RIALTO currently offers three dashboards, each designed to highlight a different aspect of Stanford’s research activity:</p>
 </div>
-<div class="my-4">
-  <h3>Publications</h3>
-  <p>The Publications dashboard provides an overview of scholarly publishing at Stanford. It helps the university understand publication trends for different research output types, fulfill reporting requirements, and plan services that support scholarly communication.</p>
-  <%= link_to publications_dashboard_path, class: 'su-underline' do %>
-    <i class="bi bi-box-arrow-up-right me-2"></i>Explore the Publications dashboard
-  <% end %>
-</div>
-<div class="my-4">
-  <h3>Open Access</h3>
-  <p>The Open Access dashboard reports on open access (OA) publishing across Stanford. It enables the university to monitor compliance with OA policies, plan and budget for OA support, and showcase Stanford’s OA achievements.</p>
-  <%= link_to open_access_dashboard_path, class: 'su-underline' do %>
-    <i class="bi bi-box-arrow-up-right me-2"></i>Explore the Open Access dashboard
-  <% end %>
-</div>
-<div class="my-4">
-  <h3>ORCID iD Adoption</h3>
-  <p>The ORCID iD Adoption dashboard reports on the use of ORCID iDs at Stanford by tracking the integration of Stanford researchers’ ORCID iDs with their SUNet IDs. These insights help monitor progress toward internal and external adoption goals and inform outreach efforts to improve ORCID iD uptake.</p>
-  <%= link_to orcid_adoption_dashboard_path, class: 'su-underline' do %>
-    <i class="bi bi-box-arrow-up-right me-2"></i>Explore the ORCID iD Adoption dashboard
-  <% end %>
+<div class="row">
+  <div class="col-12 col-lg-4 mb-3 mb-lg-0">
+    <div class="card h-100">
+      <div class="card-body d-flex flex-column">
+        <h3 class="card-title">Publications</h3>
+        <p>The Publications dashboard provides an overview of scholarly publishing at Stanford. It helps the university understand publication trends for different research output types, fulfill reporting requirements, and plan services that support scholarly communication.</p>
+        <%= link_to publications_dashboard_path, class: 'card-link su-underline mt-auto' do %>
+          <i class="bi bi-box-arrow-up-right me-2"></i>Explore the Publications dashboard
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-lg-4 mb-3 mb-lg-0">
+    <div class="card h-100">
+      <div class="card-body d-flex flex-column">
+        <h3 class="card-title">Open Access</h3>
+        <p>The Open Access dashboard reports on open access (OA) publishing across Stanford. It enables the university to monitor compliance with OA policies, plan and budget for OA support, and showcase Stanford's OA achievements.</p>
+        <%= link_to open_access_dashboard_path, class: 'card-link su-underline mt-auto' do %>
+          <i class="bi bi-box-arrow-up-right me-2"></i>Explore the Open Access dashboard
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-lg-4 mb-3 mb-lg-0">
+    <div class="card h-100">
+      <div class="card-body d-flex flex-column">
+        <h3 class="card-title">ORCID iD Adoption</h3>
+        <p>The ORCID iD Adoption dashboard reports on the use of ORCID iDs at Stanford by tracking the integration of Stanford researchers' ORCID iDs with their SUNet IDs. These insights help monitor progress toward internal and external adoption goals and inform outreach efforts to improve ORCID iD uptake.</p>
+        <%= link_to orcid_adoption_dashboard_path, class: 'card-link su-underline mt-auto' do %>
+          <i class="bi bi-box-arrow-up-right me-2"></i>Explore the ORCID iD Adoption dashboard
+        <% end %>
+      </div>
+    </div>
+  </div>
 </div>
 <div class="my-4">
   <h2>Data</h2>
-  <p>RIALTO aggregates research-related data from multiple sources and APIs. Stanford affiliates can explore, filter, and download this information from the dashboards, and approved users can access full datasets on the <%= link_to 'Downloads page', download_path, class: 'su-underline' %></p>
-  <p>In order to create a highly precise dataset of publications by Stanford-affiliated researchers, we collect publications associated with an ORCID iD of a Stanford author, where that author has <%= link_to 'linked their ORCID iD with their SUNet ID.', 'https://library.stanford.edu/orcid-id', class: 'su-underline' %>  We supplement this dataset with publications approved by a Stanford researcher via their <%= link_to 'Stanford Profile.', 'https://profiles.stanford.edu/', class: 'su-underline' %></p>
+  <p>RIALTO aggregates research-related data from multiple sources and APIs. Stanford affiliates can explore, filter, and download this information from the dashboards, and approved users can access full datasets on the <%= link_to 'Downloads page', download_path, class: 'su-underline' %>.</p>
+  <p>In order to create a highly precise dataset of publications by Stanford-affiliated researchers, we collect publications associated with an ORCID iD of a Stanford author, where that author has <%= link_to 'linked their ORCID iD with their SUNet ID', 'https://library.stanford.edu/orcid-id', class: 'su-underline' %>.  We supplement this dataset with publications approved by a Stanford researcher via their <%= link_to 'Stanford Profile', 'https://profiles.stanford.edu/', class: 'su-underline' %>.</p>
   <p>For more information about how we identify and report Stanford-authored publications, please see the more detailed documentation pages available in the Documentation menu of this site.</p>
   <div role="alert" class="alert alert-note d-flex shadow-sm align-items-center mt-3">
     <div role="img" aria-label="Note icon" class="bi bi-exclamation-circle-fill fs-3 me-3 align-self-center d-flex justify-content-center"></div>
     <div class="text-body">
-      <div>Want to be sure your publications are in our datasets? <%= link_to 'Link your ORCID iD to your SUNet ID.', 'https://authorize.stanford.edu/orcid/OrcidInit?', class: 'su-underline' %></div>
+      <div>Want to be sure your publications are in our datasets? <%= link_to 'Link your ORCID iD to your SUNet ID', 'https://authorize.stanford.edu/orcid/OrcidInit?', class: 'su-underline' %>.</div>
     </div>
   </div>
   <p>Consult our <%= link_to 'ORCID Guide', 'https://guides.library.stanford.edu/orcid', class: 'su-underline' %> to learn how to create and maintain an ORCID iD record that supports your research activities and professional development.</p>


### PR DESCRIPTION
Improves the About page layout by wrapping dashboard sections in Bootstrap cards. (Additionally, moves a few stray periods `.` outside of link text.)

## Before
<img width="1624" height="1006" alt="Screenshot 2026-04-22 at 11 42 43 AM" src="https://github.com/user-attachments/assets/14a86323-0753-4d6f-bf58-45897d56fa21" />

## After
<img width="1624" height="1006" alt="Screenshot 2026-04-22 at 11 43 07 AM" src="https://github.com/user-attachments/assets/279cf099-5549-46bc-ad6a-520cd656b16a" />

## AI Prompts
Prompts used in Copilot Plan mode:
> Write a plan to adjust the About page design as follows: For each of the dashboard sections (i.e., the H3s for Publications, Open Access, and ORCID iD Adoption), put this content inside of a Bootstrap "card" class, with an H3 "card-title", "card-body", and "card-link". Arrange these cards in a single horizontal row of three for desktop views, and in a stacked single column for mobile views.

> Additional adjustments:
> - Enforce a consistent height across the three horizontal cards, so that each "card-link" is vertically aligned across the bottom of the cards.
> - For the mobile view, add more vertical padding in-between the cards.