### PR TITLE
refactor to fix error with updated viewcomponent

### DIFF
--- a/app/components/download_dataset_component.rb
+++ b/app/components/download_dataset_component.rb
@@ -10,15 +10,19 @@ class DownloadDatasetComponent < ViewComponent::Base
   attr_reader :set
 
   def call
+    file_link + file_size + last_updated
+  end
+
+  private
+
+  def file_link
     tag.div(class: 'd-flex flex-row align-items-center gap-3') do
       link_to helpers.download_set_path(set), data: { turbo: false }, aria: { label: "Download #{file.filename}" },
                                               class: 'btn btn-primary my-2' do
         tag.i(class: 'bi bi-download me-2') + file.filename
-      end + file_size + last_updated
+      end
     end
   end
-
-  private
 
   def file
     DownloadFile.new(set:)


### PR DESCRIPTION
Deal with this new error:

```
bundler: failed to load command: honeybadger (/opt/app/rialto/rialto/shared/bundle/ruby/3.4.0/bin/honeybadger)
      01 /opt/app/rialto/rialto/shared/bundle/ruby/3.4.0/gems/bootsnap-1.24.0/lib/bootsnap/compile_cache/iseq.rb:51:in 'RubyVM::InstructionSequence.compile_file…
      01 /opt/app/rialto/rialto/releases/20260428174706/app/components/download_dataset_component.rb:17: syntax error, unexpected '+', expecting 'end' or dummy …
      01       end + file_size + last_updated
      01           ^
      01 /opt/app/rialto/rialto/releases/20260428174706/app/components/download_dataset_component.rb:34: syntax error, unexpected 'end'
```