### PR TITLE
Add beta badge to header

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,6 +16,12 @@
   background-position: center;
 }
 
+.rialto-beta-badge {
+  background-color: #007C92; /* Stanford Lagunita Base */
+  font-size: 1rem;
+  padding: 0.3rem;
+}
+
 .doc-content {
   padding: 0!important;
   margin-bottom: 4rem;

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -43,8 +43,9 @@
         <div class="d-flex align-items-end gap-2 flex-grow-1">
           <span class="rosette-logo me-1 align-self-start flex-shrink-0" aria-hidden="true"></span>
           <div class="me-1 flex-grow-1">
-            <div class="h1 my-0">
+            <div class="h1 my-0 d-flex align-items-center gap-2">
               <%= link_to 'RIALTO', root_path %>
+              <span class="badge rialto-beta-badge">BETA</span>
             </div>
             <span class="h2 d-block my-1">
               Research Intelligence at Stanford


### PR DESCRIPTION
Adds `BETA` badge to the header. #180
<img width="1624" height="1006" alt="Image" src="https://github.com/user-attachments/assets/71e2a25b-3866-49e6-b3e4-af824ee6b189" />