### PR TITLE
Downloads page adjustments

### DIFF
--- a/app/components/download_dataset_component.rb
+++ b/app/components/download_dataset_component.rb
@@ -10,17 +10,17 @@ class DownloadDatasetComponent < ViewComponent::Base
   attr_reader :set
 
   def call
-    file_link + file_size + last_updated
+    tag.div(class: 'd-flex flex-row align-items-center gap-3 mt-2') do
+      file_link + file_size + last_updated
+    end
   end
 
   private
 
   def file_link
-    tag.div(class: 'd-flex flex-row align-items-center gap-3') do
-      link_to helpers.download_set_path(set), data: { turbo: false }, aria: { label: "Download #{file.filename}" },
-                                              class: 'btn btn-primary my-2' do
-        tag.i(class: 'bi bi-download me-2') + file.filename
-      end
+    link_to helpers.download_set_path(set), data: { turbo: false }, aria: { label: "Download #{file.filename}" },
+                                            class: 'btn btn-primary' do
+      tag.i(class: 'bi bi-download me-2') + file.filename
     end
   end
 

--- a/app/views/downloads/index.html.erb
+++ b/app/views/downloads/index.html.erb
@@ -1,5 +1,5 @@
 <div class="my-3">
-  <%= render DashboardHeaderComponent.new(title: 'Downloads', link_text: 'Questions about the datasets? Read the documentation', help_url: documentation_url('downloads')) %>
+  <%= render DashboardHeaderComponent.new(title: 'Downloads', link_text: 'Questions about the downloads? Read the documentation', help_url: documentation_url('downloads')) %>
   <% if current_user && allowed_to?(:view?, with: RestrictedPolicy) %>
     <div class="my-2">
       The RIALTO team provides several "flattened" (or denormalized) data files. There are four files available for download below. Each consolidates information from multiple database tables into a single file. Each file is flattened to support a different level of analysis: by Publication, by School, by Department, or by Author.


### PR DESCRIPTION
The `Download zip`, `Size`, and `Last updated` somehow became stacked rather than displayed in a single row. This reverts to the original design.

## Current
<img width="1624" height="1006" alt="Screenshot 2026-06-05 at 11 17 07 AM" src="https://github.com/user-attachments/assets/0151b104-8cb6-4896-909a-1c02f8a9a48d" />

## Update
<img width="1624" height="1006" alt="Screenshot 2026-06-05 at 11 16 52 AM" src="https://github.com/user-attachments/assets/e3d89e52-2714-421a-913c-0e3ca53878de" />
