### PR TITLE
Improve H1 and link layout on mobile

### DIFF
--- a/app/components/dashboard_header_component.html.erb
+++ b/app/components/dashboard_header_component.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
-    <div class="d-flex justify-content-between">
+    <div class="d-flex flex-column flex-md-row justify-content-between gap-2">
         <h1><%= title %></h1>
-        <%= link_to @help_url, class: 'text-end su-underline' do %>
+        <%= link_to @help_url, class: 'text-start text-md-end su-underline' do %>
             <i class="bi bi-box-arrow-up-right me-1"></i> <%= link_text %>
         <% end %>
     </div>


### PR DESCRIPTION
## Before
<img width="484" height="303" alt="before-mobile" src="https://github.com/user-attachments/assets/be8ea178-d07d-4c7f-ad98-819d922c48ee" />

## After
<img width="485" height="303" alt="after-mobile" src="https://github.com/user-attachments/assets/3e1b16f2-3db7-4158-82b4-0c66127d937d" />

## Prompt
> The Dashboard pages (Publications, Open Access, ORCID iD Adoption) and the Downloads page display the H1 and "Questions?" link using justify-content-between. This is good for desktop views, but looks cramped on mobile. Update the style so that the "Questions?" link is displayed below the H1 and left-justified on mobile.