### PR TITLE
Track GA4 events for downloads, visualization tabs, and login

### DIFF
--- a/app/components/dashboard_tab_component.html.erb
+++ b/app/components/dashboard_tab_component.html.erb
@@ -1,4 +1,6 @@
-<ul class="nav nav-tabs mt-3" id="dashboard-tabs" role="tablist" data-controller="tab-url">
+<ul class="nav nav-tabs mt-3" id="dashboard-tabs" role="tablist"
+    data-controller="tab-url analytics"
+    data-analytics-dashboard-value="<%= dashboard %>">
     <% tabs.each do |tab_slug, tab_data| %>
         <li class="nav-item" role="presentation">
             <button class="nav-link <%= 'active' if tab_slug == selected_tab %>"
@@ -6,7 +8,8 @@
                 data-bs-target="#<%= "#{tab_slug}-pane" %>" type="button"
                 role="tab" aria-controls="<%= "#{tab_slug}-pane" %>"
                 aria-selected="<%= 'active' if tab_slug == selected_tab %>"
-                data-tab-name="<%= tab_slug %>" data-action="click->tab-url#updateUrl">
+                data-tab-name="<%= tab_slug %>"
+                data-action="click->tab-url#updateUrl click->analytics#trackVisualization">
                 <%= tab_data['heading'] %>
             </button>
         </li>

--- a/app/components/dashboard_tab_component.rb
+++ b/app/components/dashboard_tab_component.rb
@@ -2,11 +2,12 @@
 
 # Show the tabs above the dashboard embed
 class DashboardTabComponent < ApplicationComponent
-  def initialize(tabs:)
+  def initialize(tabs:, dashboard: nil)
     super()
     @tabs = tabs
+    @dashboard = dashboard
   end
-  attr_reader :tabs
+  attr_reader :tabs, :dashboard
 
   def selected_tab
     params[:tab] || tabs.keys.first

--- a/app/components/download_dataset_component.rb
+++ b/app/components/download_dataset_component.rb
@@ -18,8 +18,11 @@ class DownloadDatasetComponent < ViewComponent::Base
   private
 
   def file_link
-    link_to helpers.download_set_path(set), data: { turbo: false }, aria: { label: "Download #{file.filename}" },
-                                            class: 'btn btn-primary' do
+    link_to helpers.download_set_path(set),
+            data: { turbo: false, controller: 'analytics', action: 'click->analytics#trackDownload',
+                    analytics_file_name_value: file.filename },
+            aria: { label: "Download #{file.filename}" },
+            class: 'btn btn-primary' do
       tag.i(class: 'bi bi-download me-2') + file.filename
     end
   end

--- a/app/components/error_component.html.erb
+++ b/app/components/error_component.html.erb
@@ -8,7 +8,9 @@
             This page is only available to select users.
             If you would like to request access, please email:  <%= link_to 'rialto-service@lists.stanford.edu', 'mailto:rialto-service@lists.stanford.edu' %>.
           <% else %>
-            Log in to access the pages available to you. <%= link_to 'Log in', login_path(referrer:), data: { turbo: false } %>
+            Log in to access the pages available to you.
+            <%= link_to 'Log in', login_path(referrer:),
+                        data: { turbo: false, controller: 'analytics', action: 'click->analytics#trackLogin' } %>
             <div class="modal" id="modal" tabindex="-1">
               <div class="modal-dialog">
                 <div class="modal-content">

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -29,7 +29,9 @@
                 <li><%= link_to 'Logout', logout_path, class: 'dropdown-item' %></li>
               </ul>
             <% else %>
-              <%= link_to 'Login', login_path(referrer: request.original_url), class: 'nav-link' %>
+              <%= link_to 'Login', login_path(referrer: request.original_url),
+                          class: 'nav-link',
+                          data: { controller: 'analytics', action: 'click->analytics#trackLogin' } %>
             <% end %>
           </li>
         </ul>
@@ -138,7 +140,9 @@
                   <li><%= link_to 'Logout', logout_path, class: 'dropdown-item' %></li>
                 </ul>
               <% else %>
-                <%= link_to 'Login', login_path(referrer: request.original_url), class: 'nav-link' %>
+                <%= link_to 'Login', login_path(referrer: request.original_url),
+                            class: 'nav-link',
+                            data: { controller: 'analytics', action: 'click->analytics#trackLogin' } %>
               <% end %>
             </li>
             </ul>

--- a/app/javascript/controllers/analytics_controller.js
+++ b/app/javascript/controllers/analytics_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="analytics"
+export default class extends Controller {
+  static values = { fileName: String, dashboard: String }
+
+  trackDownload() {
+    if (typeof gtag === 'undefined') return
+    gtag('event', 'file_download', { file_name: this.fileNameValue })
+  }
+
+  trackVisualization(event) {
+    if (typeof gtag === 'undefined') return
+    gtag('event', 'view_visualization', {
+      dashboard: this.dashboardValue,
+      tab: event.currentTarget.dataset.tabName
+    })
+  }
+
+  trackLogin() {
+    if (typeof gtag === 'undefined') return
+    gtag('event', 'login', { method: 'Shibboleth' })
+  }
+}

--- a/app/views/open_access/show.html.erb
+++ b/app/views/open_access/show.html.erb
@@ -1,2 +1,2 @@
 <%= render DashboardHeaderComponent.new(title: 'Open Access Dashboard', help_url: documentation_url('open-access')) %>
-<%= render DashboardTabComponent.new(tabs: @tabs) %>
+<%= render DashboardTabComponent.new(tabs: @tabs, dashboard: 'Open Access Dashboard') %>

--- a/app/views/orcid_adoption/show.html.erb
+++ b/app/views/orcid_adoption/show.html.erb
@@ -1,2 +1,2 @@
 <%= render DashboardHeaderComponent.new(title: 'ORCID iD Adoption Dashboard', help_url: documentation_url('orcid-adoption')) %>
-<%= render DashboardTabComponent.new(tabs: @tabs) %>
+<%= render DashboardTabComponent.new(tabs: @tabs, dashboard: 'ORCID iD Adoption Dashboard') %>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -1,2 +1,2 @@
 <%= render DashboardHeaderComponent.new(title: 'Publications Dashboard', help_url: documentation_url('publications')) %>
-<%= render DashboardTabComponent.new(tabs: @tabs) %>
+<%= render DashboardTabComponent.new(tabs: @tabs, dashboard: 'Publications Dashboard') %>

--- a/spec/requests/downloads_spec.rb
+++ b/spec/requests/downloads_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe 'Publications' do
         expect(response.body).to include('aria-label="Download publications.zip"')
       end
 
+      it 'renders download links with analytics tracking attributes' do
+        get '/download'
+        expect(response.body).to include('data-controller="analytics"')
+        expect(response.body).to include('data-action="click-&gt;analytics#trackDownload"')
+        expect(response.body).to include('data-analytics-file-name-value="publications.zip"')
+      end
+
       it 'returns success' do
         get '/download/pubs'
         expect(response).to have_http_status(:success)

--- a/spec/requests/show_home_spec.rb
+++ b/spec/requests/show_home_spec.rb
@@ -27,5 +27,11 @@ RSpec.describe 'Show home page' do
       expect(response.body).to include('aside')
       expect(response.body).not_to include("Logged in: #{name}")
     end
+
+    it 'renders login link with analytics tracking attributes' do
+      get '/'
+
+      expect(response.body).to include('data-action="click-&gt;analytics#trackLogin"')
+    end
   end
 end

--- a/spec/system/show_publications_dashboard_spec.rb
+++ b/spec/system/show_publications_dashboard_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe 'Show orcid dashboard pages' do
       sign_in(user)
     end
 
+    it 'renders tabs with analytics tracking attributes' do
+      visit publications_dashboard_path
+
+      expect(page).to have_css('[data-analytics-dashboard-value="Publications Dashboard"]')
+      expect(page).to have_css('button[data-action*="analytics#trackVisualization"]')
+    end
+
     it 'shows the orcid dashboard stanford overview viz in tab' do
       visit publications_dashboard_path
 


### PR DESCRIPTION
Now that Google Analytics is enabled, instrument user interactions
so we can understand how the app is being used:

- Track download link clicks as `file_download` events (with file name)
- Track dashboard tab clicks as `view_visualization` events (with
  dashboard name and tab slug)
- Track login link clicks as `login` events (method: Shibboleth)

All tracking is wired via a new `analytics` Stimulus controller that
guards against gtag being unavailable (e.g. ad blockers, dev env).

Adds attribute-presence checks to the downloads, home, and publications
dashboard specs to guard against the Stimulus wiring being accidentally
removed.

I tested this branch in stage and then in prod to see if the events fire ok, and they seem to:

<img width="1714" height="1124" alt="Screenshot 2026-06-15 at 5 06 05 PM" src="https://github.com/user-attachments/assets/23fc99e9-8d5c-44f0-a3b1-f7b948419b4a" />

Co-Authored-By: Claude Sonnet 4.6