### PR TITLE
automatically resize embed

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -40,3 +40,9 @@
 .modal {
   padding-top: 35%;
 }
+
+.tableau-embed-container tableau-viz {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+}

--- a/app/components/dashboard_embed_component.html.erb
+++ b/app/components/dashboard_embed_component.html.erb
@@ -2,9 +2,8 @@
     <% if authorized? %>
         <div class="row">
             <div class="col-12">
-                <script type='module' src='<%= Settings.tableau.base_url %>/javascripts/api/tableau.embedding.3.latest.min.js'></script>
                 <tableau-viz
-                    id='tableau-viz'
+                    id='<%= "tableau-viz-#{turbo_frame_id}" %>'
                     class='justify-content-center'
                     src='<%= embed_url %>'
                     <% if token && !Rails.env.local? %> token='<%= token %>'<% end %>

--- a/app/components/dashboard_embed_component.html.erb
+++ b/app/components/dashboard_embed_component.html.erb
@@ -1,7 +1,7 @@
 <turbo-frame id="<%= turbo_frame_id %>">
     <% if authorized? %>
         <div class="row">
-            <div class="col-12">
+            <div class="col-12 tableau-embed-container">
                 <tableau-viz
                     id='<%= "tableau-viz-#{turbo_frame_id}" %>'
                     class='justify-content-center'

--- a/app/components/dashboard_tab_component.html.erb
+++ b/app/components/dashboard_tab_component.html.erb
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs mt-3" id="dashboard-tabs" role="tablist"
-    data-controller="tab-url analytics"
+    data-controller="tab-url analytics tableau-resize"
     data-analytics-dashboard-value="<%= dashboard %>">
     <% tabs.each do |tab_slug, tab_data| %>
         <li class="nav-item" role="presentation">

--- a/app/javascript/controllers/tableau_resize_controller.js
+++ b/app/javascript/controllers/tableau_resize_controller.js
@@ -1,0 +1,90 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Stabilizes Tableau sizing when embeds load via lazy turbo-frames in Bootstrap tabs.
+export default class extends Controller {
+  connect() {
+    this.handleFrameLoad = this.handleFrameLoad.bind(this)
+    this.handleTabShown = this.handleTabShown.bind(this)
+
+    this.element.addEventListener("turbo:frame-load", this.handleFrameLoad)
+    document.addEventListener("shown.bs.tab", this.handleTabShown)
+
+    this.queueResize()
+  }
+
+  disconnect() {
+    this.element.removeEventListener("turbo:frame-load", this.handleFrameLoad)
+    document.removeEventListener("shown.bs.tab", this.handleTabShown)
+  }
+
+  handleFrameLoad(event) {
+    const frame = event.target
+    if (!(frame instanceof HTMLElement)) return
+
+    const pane = frame.closest(".tab-pane")
+    if (this.isActivePane(pane)) {
+      this.queueResize(pane)
+    }
+  }
+
+  handleTabShown(event) {
+    const tabTrigger = event.target
+    if (!(tabTrigger instanceof HTMLElement)) return
+
+    const selector = tabTrigger.getAttribute("data-bs-target")
+    if (!selector) return
+
+    const pane = document.querySelector(selector)
+    if (pane instanceof HTMLElement) {
+      this.queueResize(pane)
+    }
+  }
+
+  queueResize(pane = null) {
+    const delays = [0, 100, 300]
+
+    delays.forEach((delay) => {
+      window.setTimeout(() => {
+        this.resizeVizInPane(pane)
+      }, delay)
+    })
+  }
+
+  resizeVizInPane(pane = null) {
+    const targetPane = pane || this.activePane()
+    if (!(targetPane instanceof HTMLElement)) return
+
+    const viz = targetPane.querySelector("tableau-viz")
+    if (!(viz instanceof HTMLElement)) return
+
+    const parent = viz.parentElement
+    if (!(parent instanceof HTMLElement)) return
+
+    const parentWidth = parent.clientWidth
+    if (!parentWidth) return
+
+    viz.style.display = "block"
+    viz.style.width = "100%"
+    viz.style.maxWidth = "100%"
+
+    const vizWidth = viz.getBoundingClientRect().width
+    if (vizWidth && vizWidth < parentWidth * 0.9) {
+      viz.style.width = `${parentWidth}px`
+      requestAnimationFrame(() => {
+        viz.style.width = "100%"
+        window.dispatchEvent(new Event("resize"))
+      })
+      return
+    }
+
+    window.dispatchEvent(new Event("resize"))
+  }
+
+  activePane() {
+    return this.element.parentElement?.querySelector(".tab-pane.show.active") || null
+  }
+
+  isActivePane(pane) {
+    return pane instanceof HTMLElement && pane.classList.contains("show") && pane.classList.contains("active")
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,10 @@
       type="module"
       src="https://unpkg.com/@github/auto-complete-element@latest/dist/bundle.js">
     </script>
+    <script
+      type="module"
+      src="<%= Settings.tableau.base_url %>/javascripts/api/tableau.embedding.3.latest.min.js">
+    </script>
 
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
     <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>

--- a/spec/system/open_access_dashboard_spec.rb
+++ b/spec/system/open_access_dashboard_spec.rb
@@ -18,28 +18,28 @@ RSpec.describe 'Show open access pages' do
 
       expect(page).to have_content('Open Access Dashboard')
       within('#stanford-overview-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
       end
     end
 
     it 'shows the open access schools and departments viz in tab' do
       visit open_access_dashboard_path(tab: 'department-details')
       within('#department-details-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}DepartmentDetails\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}DepartmentDetails\"]")
       end
     end
 
     it 'does show the open access school overview viz in tab' do
       visit open_access_dashboard_path(tab: 'school-overview')
       within('#school-overview-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}SchoolOverview\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}SchoolOverview\"]")
       end
     end
 
     it 'does show the open access school details viz in tab' do
       visit open_access_dashboard_path(tab: 'school-details')
       within('#school-details-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}SchoolDetails\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}SchoolDetails\"]")
       end
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe 'Show open access pages' do
     it 'shows the open access school overview viz in tab' do
       visit open_access_dashboard_path(tab: 'school-overview')
       within('#school-overview-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}SchoolOverview\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}SchoolOverview\"]")
       end
     end
   end
@@ -70,14 +70,14 @@ RSpec.describe 'Show open access pages' do
 
       expect(page).to have_content('Open Access Dashboard')
       within('#stanford-overview-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
       end
     end
 
     it 'does not show the open access department details viz in tab' do
       visit open_access_dashboard_path(tab: 'department-details')
       within('#department-details-frame') do
-        expect(page).to have_no_css('#tableau-viz')
+        expect(page).to have_no_css('tableau-viz')
       end
       expect(page).to have_content('This page is only available to Stanford-affiliated users.')
     end
@@ -85,7 +85,7 @@ RSpec.describe 'Show open access pages' do
     it 'does not show the open access school overview viz in tab' do
       visit open_access_dashboard_path(tab: 'school-overview')
       within('#school-overview-frame') do
-        expect(page).to have_no_css('#tableau-viz')
+        expect(page).to have_no_css('tableau-viz')
       end
       expect(page).to have_content('This page is only available to Stanford-affiliated users.')
     end
@@ -93,7 +93,7 @@ RSpec.describe 'Show open access pages' do
     it 'does not show the open access school details viz in tab' do
       visit open_access_dashboard_path(tab: 'school-details')
       within('#school-details-frame') do
-        expect(page).to have_no_css('#tableau-viz')
+        expect(page).to have_no_css('tableau-viz')
       end
       expect(page).to have_content('This page is only available to Stanford-affiliated users.')
     end

--- a/spec/system/show_orcid_dashboard_spec.rb
+++ b/spec/system/show_orcid_dashboard_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe 'Show orcid dashboard pages' do
 
       expect(page).to have_content('ORCID iD Adoption Dashboard')
       within('#stanford-overview-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
       end
     end
 
     it 'shows the orcid dashboard schools and departments viz in tab' do
       visit orcid_adoption_dashboard_path(tab: 'department-details')
       within('#department-details-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}DepartmentDetails\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}DepartmentDetails\"]")
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe 'Show orcid dashboard pages' do
       visit orcid_adoption_dashboard_path(tab: 'researcher-details')
       expect(page).to have_content('This page is only available to select users.')
       within('#researcher-details-frame') do
-        expect(page).to have_no_css('#tableau-viz')
+        expect(page).to have_no_css('tableau-viz')
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe 'Show orcid dashboard pages' do
     it 'shows the orcid dashboard individual researchers viz in tab' do
       visit orcid_adoption_dashboard_path(tab: 'researcher-details')
       within('#researcher-details-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}ResearcherDetails\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}ResearcherDetails\"]")
       end
     end
   end
@@ -64,14 +64,14 @@ RSpec.describe 'Show orcid dashboard pages' do
 
       expect(page).to have_content('ORCID iD Adoption Dashboard')
       within('#stanford-overview-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
       end
     end
 
     it 'does not show the orcid dashboard schools and departments viz in tab' do
       visit orcid_adoption_dashboard_path(tab: 'department-details')
       within('#department-details-frame') do
-        expect(page).to have_no_css('#tableau-viz')
+        expect(page).to have_no_css('tableau-viz')
       end
       expect(page).to have_content('This page is only available to Stanford-affiliated users.')
     end
@@ -79,7 +79,7 @@ RSpec.describe 'Show orcid dashboard pages' do
     it 'does not show the orcid dashboard individual researchers viz in tab' do
       visit orcid_adoption_dashboard_path(tab: 'researcher-details')
       within('#researcher-details-frame') do
-        expect(page).to have_no_css('#tableau-viz')
+        expect(page).to have_no_css('tableau-viz')
       end
       expect(page).to have_content('This page is only available to Stanford-affiliated users.')
     end

--- a/spec/system/show_publications_dashboard_spec.rb
+++ b/spec/system/show_publications_dashboard_spec.rb
@@ -25,28 +25,28 @@ RSpec.describe 'Show orcid dashboard pages' do
 
       expect(page).to have_content('Publications Dashboard')
       within('#stanford-overview-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
       end
     end
 
     it 'shows the orcid dashboard department details viz in tab' do
       visit publications_dashboard_path(tab: 'department-details')
       within('#department-details-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}DepartmentDetails\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}DepartmentDetails\"]")
       end
     end
 
     it 'shows the orcid dashboard type overview viz in tab' do
       visit publications_dashboard_path(tab: 'type-overview')
       within('#type-overview-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}TypeOverview\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}TypeOverview\"]")
       end
     end
 
     it 'shows the orcid dashboard school details viz in tab' do
       visit publications_dashboard_path(tab: 'school-details')
       within('#school-details-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}SchoolDetails\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}SchoolDetails\"]")
       end
     end
   end
@@ -62,7 +62,7 @@ RSpec.describe 'Show orcid dashboard pages' do
     it 'shows the orcid dashboard school details viz in tab' do
       visit publications_dashboard_path(tab: 'school-details')
       within('#school-details-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}SchoolDetails\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}SchoolDetails\"]")
       end
     end
   end
@@ -77,14 +77,14 @@ RSpec.describe 'Show orcid dashboard pages' do
 
       expect(page).to have_content('Publications Dashboard')
       within('#stanford-overview-frame') do
-        expect(page).to have_css("#tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
+        expect(page).to have_css("tableau-viz[src=\"#{tableau_url}StanfordOverview\"]")
       end
     end
 
     it 'does not show the orcid dashboard schools and departments viz in tab' do
       visit publications_dashboard_path(tab: 'department-details')
       within('#department-details-frame') do
-        expect(page).to have_no_css('#tableau-viz')
+        expect(page).to have_no_css('tableau-viz')
       end
       expect(page).to have_content('This page is only available to Stanford-affiliated users.')
     end
@@ -92,7 +92,7 @@ RSpec.describe 'Show orcid dashboard pages' do
     it 'does not show the orcid dashboard school details viz in tab' do
       visit publications_dashboard_path(tab: 'school-details')
       within('#school-details-frame') do
-        expect(page).to have_no_css('#tableau-viz')
+        expect(page).to have_no_css('tableau-viz')
       end
       expect(page).to have_content('This page is only available to Stanford-affiliated users.')
     end


### PR DESCRIPTION
Resize embedded tableau visualization pane each time a new tab is clicked to avoid race conditions in the lazy-load that cause the width of the tab to be narrow (because the tab is hidden and there is not content yet when it is shown by the browser before the content is loaded).

I came up with the theory, and then Claude suggested it was correct and came up with a few fixes:
1. Load the tableau JS code only once in the app and not in each embed.
2. Ensure each embed div has a unique ID to avoid browser confusion.
3. Add a stimulus controller to resize the div when it detects a new tab is shown (after some timeouts to be sure the content is loaded).
4. Ensure embed div starts out at 100% (my idea, just to reinforce this, even though the lazy loading and hidden tabs may still have a narrow width when first shown since there is no content yet)

(mostly) Claude written code.

The stimulus controller may be overkill and its possible we could simplify it.