### PR TITLE
Update /download route to /downloads

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get '/download', to: 'downloads#index', as: 'download'
-  get '/download/:set', to: 'downloads#download', as: 'download_set',
-                        constraints: { set: /pubs|author|department|school/ }
+  get '/downloads', to: 'downloads#index', as: 'download'
+  get '/downloads/:set', to: 'downloads#download', as: 'download_set',
+                         constraints: { set: /pubs|author|department|school/ }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   get '/webauth/login', to: 'authentication#login', as: 'login'
   get '/webauth/logout', to: 'authentication#logout', as: 'logout'

--- a/spec/requests/downloads_spec.rb
+++ b/spec/requests/downloads_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe 'Publications' do
   describe 'GET /index' do
     context 'when user is not logged in' do
       it 'returns login alert' do
-        get '/download'
+        get '/downloads'
         expect(response).to have_http_status(:success)
         expect(response.body).to include 'This page is only available to Stanford-affiliated users.'
       end
 
       it 'returns unauthorized for no user' do
-        get '/download/author'
+        get '/downloads/author'
         expect(response).to have_http_status(:redirect)
       end
 
       it 'returns not found' do
-        get '/download/made_up'
+        get '/downloads/made_up'
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -30,19 +30,19 @@ RSpec.describe 'Publications' do
       end
 
       it 'returns page info' do
-        get '/download'
+        get '/downloads'
         expect(response).to have_http_status(:success)
         expect(response.body).to include 'This page is only available to select users.'
       end
 
       it 'returns unauthorized' do
-        get '/download/author'
+        get '/downloads/author'
         expect(response.body).to eq '{"error":"You are not authorized to access this file."}'
         expect(response).to have_http_status(:unauthorized)
       end
 
       it 'returns failure' do
-        get '/download/made_up'
+        get '/downloads/made_up'
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -56,7 +56,7 @@ RSpec.describe 'Publications' do
       end
 
       it 'returns page info' do
-        get '/download'
+        get '/downloads'
         expect(response).to have_http_status(:success)
         expect(response.body).to include 'publications_by_department.zip'
         expect(response.body).to include 'Size: 420 KB (uncompressed)'
@@ -64,19 +64,19 @@ RSpec.describe 'Publications' do
       end
 
       it 'renders download links with analytics tracking attributes' do
-        get '/download'
+        get '/downloads'
         expect(response.body).to include('data-controller="analytics"')
         expect(response.body).to include('data-action="click-&gt;analytics#trackDownload"')
         expect(response.body).to include('data-analytics-file-name-value="publications.zip"')
       end
 
       it 'returns success' do
-        get '/download/pubs'
+        get '/downloads/pubs'
         expect(response).to have_http_status(:success)
       end
 
       it 'returns not found' do
-        get '/download/made_up'
+        get '/downloads/made_up'
         expect(response).to have_http_status(:not_found)
       end
     end


### PR DESCRIPTION
For consistency with the menu navigation and page title, update the /download route to /downloads.

Prompt: Change the Downlaods page route from /download to /downloads and update any corresponding specs.