### PR TITLE
Add DUA form link and update text

### DIFF
--- a/app/components/error_component.html.erb
+++ b/app/components/error_component.html.erb
@@ -5,8 +5,7 @@
       <div class="fw-semibold"><%= alert_heading %></div>
       <div<% unless current_user %> data-controller="check-login" data-check-login-link-value="<%= login_url(referrer:) %>"<% end %>>
           <% if current_user %>
-            This page is only available to select users.
-            If you would like to request access, please email:  <%= link_to 'rialto-service@lists.stanford.edu', 'mailto:rialto-service@lists.stanford.edu' %>.
+            If you would like to request access, please complete the <%= link_to 'Data Use Agreement', dua_form_url %> form. A member of the RIALTO team will respond as quickly as possible.
           <% else %>
             Log in to access the pages available to you.
             <%= link_to 'Log in', login_path(referrer:),

--- a/app/components/error_component.rb
+++ b/app/components/error_component.rb
@@ -7,10 +7,14 @@ class ErrorComponent < ViewComponent::Base
   def alert_heading
     return 'This page is only available to Stanford-affiliated users.' unless current_user
 
-    'This page is only available to select users.'
+    'This page is only available to approved users.'
   end
 
   def referrer
     request.headers['Turbo-Frame'] ? request.referer : request.original_url
+  end
+
+  def dua_form_url
+    Settings.forms['data-use-agreement']
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,3 +63,6 @@ docs:
   publications: https://docs.google.com/document/d/e/2PACX-1vRIzrc-kYD7ZK7WmHXkR5D6IV422KNY2dH6WG-ZpRW2HQ6dxWa1a__n1CM1PBxX1qeWA_0a9zw99odk/pub
   downloads: https://docs.google.com/document/d/e/2PACX-1vT08NOnlgLq6J3MAcvpqaZHLubNWZ0JkkgaBukV0GZ8KkVy8RdBFQnvPnPzmezRcW5K1YTO-ZiW2NLm/pub
   organization-data: https://docs.google.com/document/d/e/2PACX-1vQk5uLwRfJwYPsn6aO0jd4I9WFtiVycbfWXu0fDbHrtGkPhCtdgXZAM_KP9c9Sq68wjJzsBf5vzR4c4/pub
+
+forms:
+  data-use-agreement: https://docs.google.com/forms/d/e/1FAIpQLSfRSKW1IrDS_KmnPEggjUWpB3PB_BwqfbL7S0lcbnJaTITI0g/viewform

--- a/spec/requests/downloads_spec.rb
+++ b/spec/requests/downloads_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Publications' do
       it 'returns page info' do
         get '/downloads'
         expect(response).to have_http_status(:success)
-        expect(response.body).to include 'This page is only available to select users.'
+        expect(response.body).to include 'This page is only available to approved users.'
       end
 
       it 'returns unauthorized' do

--- a/spec/system/show_orcid_dashboard_spec.rb
+++ b/spec/system/show_orcid_dashboard_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Show orcid dashboard pages' do
 
     it 'does not show the orcid dashboard individual researchers viz in tab' do
       visit orcid_adoption_dashboard_path(tab: 'researcher-details')
-      expect(page).to have_text('This page is only available to select users.')
+      expect(page).to have_text('This page is only available to approved users.')
       within('#researcher-details-frame') do
         expect(page).to have_no_css('#tableau-viz')
       end


### PR DESCRIPTION
#210 
Partly AI-assisted. Tested using `REMOTE_USER=user ROLES=stanford rails s` and navigating to the Downloads page.