### PR TITLE
Fix aria-selected value

### DIFF
--- a/app/components/dashboard_tab_component.html.erb
+++ b/app/components/dashboard_tab_component.html.erb
@@ -7,7 +7,7 @@
                 id="<%= "#{tab_slug}-tab" %>" data-bs-toggle="tab"
                 data-bs-target="#<%= "#{tab_slug}-pane" %>" type="button"
                 role="tab" aria-controls="<%= "#{tab_slug}-pane" %>"
-                aria-selected="<%= 'active' if tab_slug == selected_tab %>"
+                aria-selected="<%= 'true' if tab_slug == selected_tab %>"
                 data-tab-name="<%= tab_slug %>"
                 data-action="click->tab-url#updateUrl click->analytics#trackVisualization">
                 <%= tab_data['heading'] %>


### PR DESCRIPTION
Currently, aria-selected is set to "active".
> The selected `tab` in a `tablist` should have the attribute aria-selected="true" set.

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-selected#tab