### PR TITLE
Update RIALTO wordmark

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -19,7 +19,8 @@
 .rialto-beta-badge {
   background-color: #007C92; /* Stanford Lagunita Base */
   font-size: 1rem;
-  padding: 0.3rem;
+  padding: 0.3rem 0.5rem 0.3rem 0.5rem;
+  font-weight: 600;
 }
 
 .doc-content {

--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -46,12 +46,10 @@
           <span class="rosette-logo me-1 align-self-start flex-shrink-0" aria-hidden="true"></span>
           <div class="me-1 flex-grow-1">
             <div class="h1 my-0 d-flex align-items-center gap-2">
-              <%= link_to 'RIALTO', root_path %>
+              <%= link_to 'RIALTO', root_path, class: 'fw-semibold' %>
+              <%= link_to 'Research Intelligence', root_path, class: 'fw-light' %>
               <span class="badge rialto-beta-badge">BETA</span>
             </div>
-            <span class="h2 d-block my-1">
-              Research Intelligence at Stanford
-            </span>
           </div>
         </div>
         <div class="navbars ms-md-auto">


### PR DESCRIPTION
## Before
<img width="2908" height="638" alt="rialto-current-1" src="https://github.com/user-attachments/assets/e1c4cc3c-c690-4b2d-8288-8426a9e6d14e" />

## After
<img width="2908" height="638" alt="rialto-nopipe-1" src="https://github.com/user-attachments/assets/ccdb6c5f-4617-4942-bd9f-e9eaba9afea4" />