### PR TITLE
Fix wordmark mobile

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -47,7 +47,7 @@
           <div class="me-1 flex-grow-1">
             <div class="h1 my-0 d-flex align-items-center gap-2">
               <%= link_to 'RIALTO', root_path, class: 'fw-semibold' %>
-              <%= link_to 'Research Intelligence', root_path, class: 'fw-light' %>
+              <%= link_to 'Research Intelligence', root_path, class: 'fw-light d-none d-md-inline' %>
               <span class="badge rialto-beta-badge">BETA</span>
             </div>
           </div>


### PR DESCRIPTION
Fix from Claude: added `d-none d-md-inline` to the "Research Intelligence" link, so it's hidden below the `md` breakpoint and only "RIALTO" + the BETA badge show on mobile; it reappears at `md` and up.

## Before
<img width="566" height="284" alt="mobile-wordmark-before" src="https://github.com/user-attachments/assets/0cdb4b6e-4540-4b55-969a-2c52105e453c" />

## After
<img width="566" height="245" alt="mobile-wordmark-after" src="https://github.com/user-attachments/assets/a556f8fb-e1ef-476e-8fa2-c3455be67e32" />