### PR TITLE
reset session on logout, ensure groups reset on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ REMOTE_USER=peter rails s
 A logged in user in a single workgroup:
 
 ```
-REMOTE_USER=peter ROLES=sul:rialto rails s
+REMOTE_USER=peter ROLES=sul:rialto-business rails s
 ```
 
 A logged in user in multiple workgroup:
 ```
-REMOTE_USER=peter ROLES=sul:rialto;sul:dlss rails s
+REMOTE_USER=peter ROLES=sul:rialto-business;sul:dlss rails s
 ```
 
 If you leave off the "REMOTE_USER", you will see the login button, but it won't do anything.

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -68,6 +68,9 @@ module Authentication
   end
 
   def start_new_session
+    # Ensure group memberships are refreshed from headers after re-authentication.
+    session.delete('groups')
+
     # Create or update a user based on the headers provided by Apache.
     User.upsert(user_attrs, unique_by: :email_address) # rubocop:disable Rails/SkipsModelValidations
   end
@@ -103,6 +106,7 @@ module Authentication
   end
 
   def terminate_session
+    reset_session
     cookies.delete(:logged_in)
   end
 end


### PR DESCRIPTION
if a user is added/removed from a workgroup, we want to be sure their session is fully cleared on logout and that any existing groups are cleared and reset on login.